### PR TITLE
修复uni-list-item组件右侧箭头图标在安卓app中不能垂直居中的问题

### DIFF
--- a/components/uni-list-item/uni-list-item.vue
+++ b/components/uni-list-item/uni-list-item.vue
@@ -232,6 +232,7 @@
 		justify-content: space-between;
 		background-color: #fff;
 		flex-direction: row;
+		align-items: center;
 	}
 
 	.uni-list-item--disabled {


### PR DESCRIPTION
修复uni-list-item组件右侧箭头图标在安卓app中不能垂直居中的问题
问题详情见官方论坛：https://ask.dcloud.net.cn/question/111979&sort_key=agree_count&sort=DESC