### PR TITLE
fix bug 运行npm run build:mp-weixin提示Error: Vue3 项目暂不支持当前小程序

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -165,7 +165,7 @@
             "enable" : true
         }
     },
-    "vueVersion" : "3",
+    // "vueVersion" : "3",
     "mp-kuaishou" : {
         "uniStatistics" : {
             "enable" : true


### PR DESCRIPTION
使用vue create -p dcloudio/uni-preset-vue创建项目后，运行npm run build:mp-weixin提示Error: Vue3 项目暂不支持当前小程序，需要删除这一个版本限制才能正常使用，详见[这里描述](https://blog.csdn.net/xueyings/article/details/144587287)